### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,12 +22,13 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   tests:
     name: "Python ${{ matrix.python-version }}"
-    # 20.04 because https://github.com/actions/python-versions
-    # does not have 2.7 and 3.6 binaries for 22.04.
-    runs-on: "ubuntu-20.04"
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -38,11 +39,16 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11-dev"
+          - "3.11"
           - "pypy-2.7"
           - "pypy-3.7"
           - "pypy-3.8"
           - "pypy-3.9"
+        # 20.04 because https://github.com/actions/python-versions
+        # does not have 2.7 and 3.6 binaries for 22.04.
+        os: ["ubuntu-20.04"]
+        include:
+          - { python-version: "3.12", os: "ubuntu-latest" }
     steps:
       - uses: "actions/checkout@v3"
         with:
@@ -50,6 +56,7 @@ jobs:
       - uses: "actions/setup-python@v4"
         with:
           python-version: "${{ matrix.python-version }}"
+          allow-prereleases: true
           cache: "pip"
       - name: "Update pip"
         run: python -m pip install --upgrade pip setuptools wheel
@@ -68,7 +75,7 @@ jobs:
           ref: ${{ inputs.tag || github.ref }}
       - uses: "actions/setup-python@v4"
         with:
-          python-version: "3.10"
+          python-version: "3.x"
           cache: "pip"
       - name: "Update pip"
         run: python -m pip install --upgrade pip setuptools wheel
@@ -77,14 +84,14 @@ jobs:
       - name: "Run 'build'"
         run: "python -m build"
       - name: "Upload sdist artifact"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: sdist
           path: |
             dist/pyasn1*.tar.gz
           if-no-files-found: error
       - name: "Upload wheel artifact"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheel
           path: |

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.x"
       - name: "Update pip"
         run: python -m pip install --upgrade pip setuptools wheel
       - name: "Install 'build' and 'twine'"

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Communications

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.5.0
 envlist =
-    py27, py36, py37, py38, py39, py310, py311, pypy27, pypy37, pypy38, pypy39
+    py27, py36, py37, py38, py39, py310, py311, py312, pypy27, pypy37, pypy38, pypy39
     cover, bandit, build
 isolated_build = true
 skip_missing_interpreters = true
@@ -46,6 +46,7 @@ python =
     3.9: py39
     3.10: py310, cover, build, bandit
     3.11: py311
+    3.12: py312
     pypy-2.7: pypy27
     pypy-3.7: pypy37
     pypy-3.8: pypy38


### PR DESCRIPTION
The [Python 3.12 release candidate is out!](https://discuss.python.org/t/python-3-12-0-release-candidate-1-released/31137?u=hugovk) :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.