### PR TITLE
Drop support for EOL Python 2.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,19 +33,17 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "2.7"
           - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
-          - "pypy-2.7"
           - "pypy-3.7"
           - "pypy-3.8"
           - "pypy-3.9"
         # 20.04 because https://github.com/actions/python-versions
-        # does not have 2.7 and 3.6 binaries for 22.04.
+        # does not have 3.6 binaries for 22.04.
         os: ["ubuntu-20.04"]
         include:
           - { python-version: "3.12", os: "ubuntu-latest" }

--- a/pyasn1_modules/pem.py
+++ b/pyasn1_modules/pem.py
@@ -5,7 +5,6 @@
 # License: http://snmplabs.com/pyasn1/license.html
 #
 import base64
-import sys
 
 stSpam, stHam, stDump = 0, 1, 2
 
@@ -38,10 +37,7 @@ def readPemBlocksFromFile(fileObj, *markers):
             else:
                 certLines.append(certLine)
         if state == stDump:
-            if sys.version_info[0] <= 2:
-                substrate = ''.join([base64.b64decode(x) for x in certLines])
-            else:
-                substrate = ''.encode().join([base64.b64decode(x.encode()) for x in certLines])
+            substrate = ''.encode().join([base64.b64decode(x.encode()) for x in certLines])
             break
     return idx, substrate
 
@@ -55,10 +51,7 @@ def readPemFromFile(fileObj,
 
 
 def readBase64fromText(text):
-    if sys.version_info[0] <= 2:
-        return base64.b64decode(text)
-    else:
-        return base64.b64decode(text.encode())
+    return base64.b64decode(text.encode())
 
 
 def readBase64FromFile(fileObj):

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,8 +27,6 @@ classifiers =
     License :: OSI Approved :: BSD License
     Natural Language :: English
     Operating System :: OS Independent
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
@@ -43,13 +41,10 @@ classifiers =
     Topic :: Software Development :: Libraries :: Python Modules
 
 [options]
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*
+python_requires = >=3.6
 zip_safe = True
 setup_requires = setuptools
 install_requires =
     pyasn1>=0.4.6,<0.6.0
 packages =
     pyasn1_modules
-
-[bdist_wheel]
-universal = 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.5.0
 envlist =
-    py27, py36, py37, py38, py39, py310, py311, py312, pypy27, pypy37, pypy38, pypy39
+    py{36, 37, 38, 39, 310, 311, 312, py37, py38, py39}
     cover, bandit, build
 isolated_build = true
 skip_missing_interpreters = true
@@ -39,7 +39,6 @@ commands =
 
 [gh-actions]
 python =
-    2.7: py27
     3.6: py36
     3.7: py37
     3.8: py38
@@ -47,7 +46,6 @@ python =
     3.10: py310, cover, build, bandit
     3.11: py311
     3.12: py312
-    pypy-2.7: pypy27
     pypy-3.7: pypy37
     pypy-3.8: pypy38
     pypy-3.9: pypy39


### PR DESCRIPTION
Built on top of https://github.com/pyasn1/pyasn1-modules/pull/11 to avoid conflicts.