### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,7 @@ jobs:
         os: ["ubuntu-22.04"]
         include:
           - { python-version: "3.12", os: "ubuntu-latest" }
+          - { python-version: "3.13", os: "ubuntu-latest" }
     steps:
       - uses: "actions/checkout@v4"
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,10 +43,10 @@ jobs:
         include:
           - { python-version: "3.12", os: "ubuntu-latest" }
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
         with:
           ref: ${{ inputs.tag || github.ref }}
-      - uses: "actions/setup-python@v4"
+      - uses: "actions/setup-python@v5"
         with:
           python-version: "${{ matrix.python-version }}"
           allow-prereleases: true
@@ -63,10 +63,10 @@ jobs:
     runs-on: "ubuntu-latest"
     needs: tests
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
         with:
           ref: ${{ inputs.tag || github.ref }}
-      - uses: "actions/setup-python@v4"
+      - uses: "actions/setup-python@v5"
         with:
           python-version: "3.x"
           cache: "pip"
@@ -77,14 +77,14 @@ jobs:
       - name: "Run 'build'"
         run: "python -m build"
       - name: "Upload sdist artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sdist
           path: |
             dist/pyasn1*.tar.gz
           if-no-files-found: error
       - name: "Upload wheel artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheel
           path: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Communications

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.5.0
 envlist =
-    py{38, 39, 310, 311, 312, py38, py39}
+    py{38, 39, 310, 311, 312, 313, py38, py39}
     cover, bandit, build
 isolated_build = true
 skip_missing_interpreters = true
@@ -44,5 +44,6 @@ python =
     3.10: py310, cover, build, bandit
     3.11: py311
     3.12: py312
+    3.13: py313
     pypy-3.8: pypy38
     pypy-3.9: pypy39


### PR DESCRIPTION
The Python 3.13 release candidate is out now! :rocket:

The Release Manager has issued a [call to action](https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703?u=hugovk]):

> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.13 compatibilities during this phase, and where necessary publish Python 3.13 wheels on PyPI to be ready for the final release of 3.13.0. Any binary wheels built against Python 3.13.0rc1 **will work** with future versions of Python 3.13. As always, report any issues to [the Python bug tracker](https://github.com/python/cpython/issues).